### PR TITLE
bugfix: implement solution to unblock usage of library

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -29,7 +29,9 @@ export async function buildComponent(path: string, props: Record<string, unknown
 	const hash = getHash({ path, props, astroConfig: buildOptions.astroConfig });
 
 	const projectRoot = TESTER_DIR + '/.test/' + `test-${hash}`;
-	const pathToComponent = relative(projectRoot + '/src/pages', path);
+	// TODO: https://github.com/sindresorhus/slash;
+	// We need to ensure that conventional forward slashes are used.
+	const pathToComponent = relative(projectRoot + '/src/pages', path).replace(/\\/g, '/');
 
 	// If the dir already exists, no need to scaffold a new one unless the user request it
 	if (!existsSync(projectRoot) || buildOptions?.forceNewEnvironnement) {


### PR DESCRIPTION
Currently the `index.astro` which is used to test the component under test generates imports following the platform specific path separator. However, this leads to imports that do not follow the conventional forward slash based imports that are found in the Node ecosystem. Forward slashes also work on Windows. Additionally, without this change Vite errors out with confusing error messages as the backslashes are interpreted as escape sequences.

I have tested this change on Windows and Linux (via GitHub Codespaces).

Generated `index.astro` on every platform:

```diff
---
---import Component from "..\..\..\..\..\..\src\Component.astro"
+++import Component from "../../../../../../src/Component.astro"
const props = {}
---

<Component {...props} />
```