### PR TITLE
feat: Add CommonJS support

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -4,6 +4,7 @@ module.exports = {
 	semi: true,
 	singleQuote: true,
 	tabWidth: 2,
+	useTabs: true,
 	trailingComma: 'es5',
 	overrides: [
 		{

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "require": "./dist/cjs/index.js",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js"
     }
   },
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,20 @@
 {
   "name": "astro-component-tester",
   "description": "Utility to test Astro components",
-  "version": "0.4.0",
-  "type": "module",
-  "exports": {
-    ".": "./dist/index.js"
-  },
+  "version": "0.5.0",
+  "main": "dist/cjs/index.js",
+  "module": "dist/index.js",
+  "jsnext:main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],
-  "types": "./dist/index.d.ts",
   "author": "Princesseuh",
   "license": "MIT",
   "scripts": {
-    "build": "tsc --module commonjs --target es5 --outDir dist/cjs",
+    "build:esm": "tsc",
+    "build:cjs": "tsc --module commonjs --target es5 --outDir dist/cjs",
+    "build": "npm run build:esm && npm run build:cjs",
     "dev": "tsc --watch",
     "format": "prettier -w .",
     "lint": "eslint . --ext .ts,.js",

--- a/package.json
+++ b/package.json
@@ -2,16 +2,16 @@
   "name": "astro-component-tester",
   "description": "Utility to test Astro components",
   "version": "0.5.0",
-  "main": "dist/cjs/index.js",
-  "module": "dist/index.js",
-  "jsnext:main": "dist/index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/cjs/index.js",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
-  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",
   "jsnext:main": "dist/index.js",
+  "exports": {
+    ".": {
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Princesseuh",
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --module commonjs --target es5 --outDir dist/cjs",
     "dev": "tsc --watch",
     "format": "prettier -w .",
     "lint": "eslint . --ext .ts,.js",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   "license": "MIT",
   "scripts": {
     "build:esm": "tsc",
-    "build:cjs": "tsc --module commonjs --target es5 --outDir dist/cjs",
+    "build:cjs": "tsc --module commonjs --target es5 --outDir dist/cjs && npm run replace-cjs:dirname",
     "build": "npm run build:esm && npm run build:cjs",
+    "replace-cjs:dirname": "replace-in-file ./dist/cjs/**  --configFile=./scripts/replace-in-files-dirname.js",
     "dev": "tsc --watch",
     "format": "prettier -w .",
     "lint": "eslint . --ext .ts,.js",
@@ -40,6 +41,7 @@
     "eslint-config-prettier": "^8.4.0",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.5.1",
+    "replace-in-file": "^6.3.5",
     "typescript": "^4.5.5"
   }
 }

--- a/scripts/replace-in-files-dirname.js
+++ b/scripts/replace-in-files-dirname.js
@@ -1,5 +1,5 @@
 module.exports = {
-  // /* replace-in-file-dirname-start */ --ALL-CODE-BETWEEN-- /* replace-in-file-dirname-end */
-  from: /\/\* replace-in-file-dirname-start \*\/([\s\S]*?)\/\* replace-in-file-dirname-end \*\//,
-  to: 'return __dirname;',
+	// /* replace-in-file-dirname-start */ --ALL-CODE-BETWEEN-- /* replace-in-file-dirname-end */
+	from: /\/\* replace-in-file-dirname-start \*\/([\s\S]*?)\/\* replace-in-file-dirname-end \*\//,
+	to: 'return __dirname;',
 };

--- a/scripts/replace-in-files-dirname.js
+++ b/scripts/replace-in-files-dirname.js
@@ -1,0 +1,5 @@
+module.exports = {
+  // /* replace-in-file-dirname-start */ --ALL-CODE-BETWEEN-- /* replace-in-file-dirname-end */
+  from: /\/\* replace-in-file-dirname-start \*\/([\s\S]*?)\/\* replace-in-file-dirname-end \*\//,
+  to: 'return __dirname;',
+};

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,22 +1,20 @@
 import { mkdir, writeFile } from 'fs/promises';
 import { execSync } from 'child_process';
-import { relative, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { relative } from 'path';
 import { createHash } from 'crypto';
 import { existsSync, rmSync } from 'fs';
 import { AstroUserConfig } from 'astro';
 
-// I'm sure there must be an easier way to do this?
-const TESTER_DIR = dirname(fileURLToPath(import.meta.url)).slice(0, -5);
+const TESTER_DIR = __dirname;
 
 export interface BuildOption {
-	astroConfig?: AstroUserConfig;
-	forceNewEnvironnement?: boolean;
+  astroConfig?: AstroUserConfig;
+  forceNewEnvironnement?: boolean;
 }
 
 export interface BuildResult {
-	projectRoot: string;
-	builtFile: string;
+  projectRoot: string;
+  builtFile: string;
 }
 
 /**
@@ -26,16 +24,16 @@ export interface BuildResult {
  * @returns The path to the built component
  */
 export async function buildComponent(path: string, props: Record<string, unknown>, buildOptions: BuildOption): Promise<BuildResult> {
-	const hash = getHash({ path, props, astroConfig: buildOptions.astroConfig });
+  const hash = getHash({ path, props, astroConfig: buildOptions.astroConfig });
 
-	const projectRoot = TESTER_DIR + '/.test/' + `test-${hash}`;
-	// TODO: https://github.com/sindresorhus/slash;
-	// We need to ensure that conventional forward slashes are used.
-	const pathToComponent = relative(projectRoot + '/src/pages', path).replace(/\\/g, '/');
+  const projectRoot = TESTER_DIR + '/.test/' + `test-${hash}`;
+  // TODO: https://github.com/sindresorhus/slash;
+  // We need to ensure that conventional forward slashes are used.
+  const pathToComponent = relative(projectRoot + '/src/pages', path).replace(/\\/g, '/');
 
-	// If the dir already exists, no need to scaffold a new one unless the user request it
-	if (!existsSync(projectRoot) || buildOptions?.forceNewEnvironnement) {
-		const content = dedent(`
+  // If the dir already exists, no need to scaffold a new one unless the user request it
+  if (!existsSync(projectRoot) || buildOptions?.forceNewEnvironnement) {
+    const content = dedent(`
         ---
             import Component from "${pathToComponent}"
             const props = ${JSON.stringify(props) || '{}'}
@@ -44,46 +42,46 @@ export async function buildComponent(path: string, props: Record<string, unknown
         <Component {...props} />
         `).trim();
 
-		// Set the default Astro config if the user didn't provide one
-		buildOptions.astroConfig ??= {};
-		const config = `export default (${JSON.stringify(buildOptions.astroConfig)});`;
+    // Set the default Astro config if the user didn't provide one
+    buildOptions.astroConfig ??= {};
+    const config = `export default (${JSON.stringify(buildOptions.astroConfig)});`;
 
-		// Scaffold an environnement for building the component
-		await mkdir(projectRoot + '/src/pages/', { recursive: true });
-		await writeFile(projectRoot + '/src/pages/' + 'index.astro', content, {
-			encoding: 'utf-8',
-		});
-		await writeFile(projectRoot + '/astro.config.js', config, {
-			encoding: 'utf-8',
-		});
-	}
+    // Scaffold an environnement for building the component
+    await mkdir(projectRoot + '/src/pages/', { recursive: true });
+    await writeFile(projectRoot + '/src/pages/' + 'index.astro', content, {
+      encoding: 'utf-8',
+    });
+    await writeFile(projectRoot + '/astro.config.js', config, {
+      encoding: 'utf-8',
+    });
+  }
 
-	// Build it using the Astro CLI
-	execSync('npx astro build', { cwd: projectRoot });
+  // Build it using the Astro CLI
+  execSync('npx astro build', { cwd: projectRoot });
 
-	return {
-		projectRoot,
-		builtFile: projectRoot + '/dist/index.html',
-	};
+  return {
+    projectRoot,
+    builtFile: projectRoot + '/dist/index.html',
+  };
 }
 
 const dedent = (str: string) =>
-	str
-		.split('\n')
-		.map((ln) => ln.trimStart())
-		.join('\n');
+  str
+    .split('\n')
+    .map((ln) => ln.trimStart())
+    .join('\n');
 
 function getHash(options: Record<string, unknown>) {
-	const hash = createHash('sha256');
+  const hash = createHash('sha256');
 
-	hash.update(JSON.stringify(options));
+  hash.update(JSON.stringify(options));
 
-	return hash.digest('base64url').toString().substring(0, 6);
+  return hash.digest('base64url').toString().substring(0, 6);
 }
 
 /**
  * Remove all test directories created
  */
 export function cleanTests() {
-	rmSync(TESTER_DIR + '/.test/', { recursive: true, force: true });
+  rmSync(TESTER_DIR + '/.test/', { recursive: true, force: true });
 }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,12 +1,20 @@
 import { mkdir, writeFile } from 'fs/promises';
 import { execSync } from 'child_process';
-import { dirname, relative } from 'path';
+import { dirname as getDirname, relative } from 'path';
 import { fileURLToPath } from 'url';
 import { createHash } from 'crypto';
 import { existsSync, rmSync } from 'fs';
 import { AstroUserConfig } from 'astro';
 
-const TESTER_DIR = typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url));
+const dirname = (() => {
+  /* replace-in-file-dirname-start */
+  return typeof __dirname === 'undefined'
+    ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      getDirname(fileURLToPath(import.meta.url)).slice(0, -5)
+    : __dirname;
+  /* replace-in-file-dirname-end */
+})();
 
 export interface BuildOption {
   astroConfig?: AstroUserConfig;
@@ -27,7 +35,7 @@ export interface BuildResult {
 export async function buildComponent(path: string, props: Record<string, unknown>, buildOptions: BuildOption): Promise<BuildResult> {
   const hash = getHash({ path, props, astroConfig: buildOptions.astroConfig });
 
-  const projectRoot = TESTER_DIR + '/.test/' + `test-${hash}`;
+  const projectRoot = dirname + '/.test/' + `test-${hash}`;
   // TODO: https://github.com/sindresorhus/slash;
   // We need to ensure that conventional forward slashes are used.
   const pathToComponent = relative(projectRoot + '/src/pages', path).replace(/\\/g, '/');
@@ -84,5 +92,5 @@ function getHash(options: Record<string, unknown>) {
  * Remove all test directories created
  */
 export function cleanTests() {
-  rmSync(TESTER_DIR + '/.test/', { recursive: true, force: true });
+  rmSync(dirname + '/.test/', { recursive: true, force: true });
 }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,11 +1,12 @@
 import { mkdir, writeFile } from 'fs/promises';
 import { execSync } from 'child_process';
-import { relative } from 'path';
+import { dirname, relative } from 'path';
+import { fileURLToPath } from 'url';
 import { createHash } from 'crypto';
 import { existsSync, rmSync } from 'fs';
 import { AstroUserConfig } from 'astro';
 
-const TESTER_DIR = __dirname;
+const TESTER_DIR = typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url));
 
 export interface BuildOption {
   astroConfig?: AstroUserConfig;

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -7,23 +7,23 @@ import { existsSync, rmSync } from 'fs';
 import { AstroUserConfig } from 'astro';
 
 const dirname = (() => {
-  /* replace-in-file-dirname-start */
-  return typeof __dirname === 'undefined'
-    ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      getDirname(fileURLToPath(import.meta.url)).slice(0, -5)
-    : __dirname;
-  /* replace-in-file-dirname-end */
+	/* replace-in-file-dirname-start */
+	return typeof __dirname === 'undefined'
+		? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		  // @ts-ignore
+		  getDirname(fileURLToPath(import.meta.url)).slice(0, -5)
+		: __dirname;
+	/* replace-in-file-dirname-end */
 })();
 
 export interface BuildOption {
-  astroConfig?: AstroUserConfig;
-  forceNewEnvironnement?: boolean;
+	astroConfig?: AstroUserConfig;
+	forceNewEnvironnement?: boolean;
 }
 
 export interface BuildResult {
-  projectRoot: string;
-  builtFile: string;
+	projectRoot: string;
+	builtFile: string;
 }
 
 /**
@@ -33,16 +33,16 @@ export interface BuildResult {
  * @returns The path to the built component
  */
 export async function buildComponent(path: string, props: Record<string, unknown>, buildOptions: BuildOption): Promise<BuildResult> {
-  const hash = getHash({ path, props, astroConfig: buildOptions.astroConfig });
+	const hash = getHash({ path, props, astroConfig: buildOptions.astroConfig });
 
-  const projectRoot = dirname + '/.test/' + `test-${hash}`;
-  // TODO: https://github.com/sindresorhus/slash;
-  // We need to ensure that conventional forward slashes are used.
-  const pathToComponent = relative(projectRoot + '/src/pages', path).replace(/\\/g, '/');
+	const projectRoot = dirname + '/.test/' + `test-${hash}`;
+	// TODO: https://github.com/sindresorhus/slash;
+	// We need to ensure that conventional forward slashes are used.
+	const pathToComponent = relative(projectRoot + '/src/pages', path).replace(/\\/g, '/');
 
-  // If the dir already exists, no need to scaffold a new one unless the user request it
-  if (!existsSync(projectRoot) || buildOptions?.forceNewEnvironnement) {
-    const content = dedent(`
+	// If the dir already exists, no need to scaffold a new one unless the user request it
+	if (!existsSync(projectRoot) || buildOptions?.forceNewEnvironnement) {
+		const content = dedent(`
         ---
             import Component from "${pathToComponent}"
             const props = ${JSON.stringify(props) || '{}'}
@@ -51,46 +51,46 @@ export async function buildComponent(path: string, props: Record<string, unknown
         <Component {...props} />
         `).trim();
 
-    // Set the default Astro config if the user didn't provide one
-    buildOptions.astroConfig ??= {};
-    const config = `export default (${JSON.stringify(buildOptions.astroConfig)});`;
+		// Set the default Astro config if the user didn't provide one
+		buildOptions.astroConfig ??= {};
+		const config = `export default (${JSON.stringify(buildOptions.astroConfig)});`;
 
-    // Scaffold an environnement for building the component
-    await mkdir(projectRoot + '/src/pages/', { recursive: true });
-    await writeFile(projectRoot + '/src/pages/' + 'index.astro', content, {
-      encoding: 'utf-8',
-    });
-    await writeFile(projectRoot + '/astro.config.js', config, {
-      encoding: 'utf-8',
-    });
-  }
+		// Scaffold an environnement for building the component
+		await mkdir(projectRoot + '/src/pages/', { recursive: true });
+		await writeFile(projectRoot + '/src/pages/' + 'index.astro', content, {
+			encoding: 'utf-8',
+		});
+		await writeFile(projectRoot + '/astro.config.js', config, {
+			encoding: 'utf-8',
+		});
+	}
 
-  // Build it using the Astro CLI
-  execSync('npx astro build', { cwd: projectRoot });
+	// Build it using the Astro CLI
+	execSync('npx astro build', { cwd: projectRoot });
 
-  return {
-    projectRoot,
-    builtFile: projectRoot + '/dist/index.html',
-  };
+	return {
+		projectRoot,
+		builtFile: projectRoot + '/dist/index.html',
+	};
 }
 
 const dedent = (str: string) =>
-  str
-    .split('\n')
-    .map((ln) => ln.trimStart())
-    .join('\n');
+	str
+		.split('\n')
+		.map((ln) => ln.trimStart())
+		.join('\n');
 
 function getHash(options: Record<string, unknown>) {
-  const hash = createHash('sha256');
+	const hash = createHash('sha256');
 
-  hash.update(JSON.stringify(options));
+	hash.update(JSON.stringify(options));
 
-  return hash.digest('base64url').toString().substring(0, 6);
+	return hash.digest('base64url').toString().substring(0, 6);
 }
 
 /**
  * Remove all test directories created
  */
 export function cleanTests() {
-  rmSync(dirname + '/.test/', { recursive: true, force: true });
+	rmSync(dirname + '/.test/', { recursive: true, force: true });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -616,7 +616,7 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -901,6 +901,15 @@ cli-spinners@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
   integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone@^1.0.2:
   version "1.0.4"
@@ -1851,6 +1860,11 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
@@ -1901,6 +1915,18 @@ glob@^7.1.3:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.2.0:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -3078,6 +3104,13 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -3526,6 +3559,20 @@ remark-smartypants@^2.0.0:
     retext-smartypants "^5.1.0"
     unist-util-visit "^4.1.0"
 
+replace-in-file@^6.3.5:
+  version "6.3.5"
+  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-6.3.5.tgz#ff956b0ab5bc96613207d603d197cd209400a654"
+  integrity sha512-arB9d3ENdKva2fxRnSjwBEXfK1npgyci7ZZuwysgAp7ORjHSyxz6oqIjTEv8R0Ydl4Ll7uOAZXL4vbkhGIizCg==
+  dependencies:
+    chalk "^4.1.2"
+    glob "^7.2.0"
+    yargs "^17.2.1"
+
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -3768,7 +3815,7 @@ srcset-parse@^1.1.0:
   resolved "https://registry.yarnpkg.com/srcset-parse/-/srcset-parse-1.1.0.tgz#73f787f38b73ede2c5af775e0a3465579488122b"
   integrity sha512-JWp4cG2eybkvKA1QUHGoNK6JDEYcOnSuhzNGjZuYUPqXreDl/VkkvP2sZW7Rmh+icuCttrR9ccb2WPIazyM/Cw==
 
-string-width@^4.1.0:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3817,7 +3864,7 @@ stringify-entities@^4.0.0, stringify-entities@^4.0.2:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-strip-ansi@^6.0.1:
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4354,6 +4401,15 @@ word-wrap@^1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.0.1.tgz#2101e861777fec527d0ea90c57c6b03aac56a5b3"
@@ -4368,6 +4424,11 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
@@ -4378,10 +4439,23 @@ yaml@^1.10.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@^21.0.1:
+yargs-parser@^21.0.0, yargs-parser@^21.0.1:
   version "21.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
+
+yargs@^17.2.1:
+  version "17.5.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.1.tgz#e109900cab6fcb7fd44b1d8249166feb0b36e58e"
+  integrity sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Currently, the `astro-component-tester` does not compile into **CommonJS** modules, which makes it not working with **Jest**.

Jest is working with ES Modules only with `--experimental-vm-modules` tag.

I have added some modifications in package.json and created a script that will remove `import.meta.url` which is banned in Jest if it is not running with that tag.

Modifications do not break anything that was before, because it compiles into CommonJS separately.