### PR TITLE
Use mjs extension for Astro Config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-component-tester",
   "description": "Utility to test Astro components",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -60,7 +60,7 @@ export async function buildComponent(path: string, props: Record<string, unknown
 		await writeFile(projectRoot + '/src/pages/' + 'index.astro', content, {
 			encoding: 'utf-8',
 		});
-		await writeFile(projectRoot + '/astro.config.js', config, {
+		await writeFile(projectRoot + '/astro.config.mjs', config, {
 			encoding: 'utf-8',
 		});
 	}


### PR DESCRIPTION
I'm getting `Unexpected token 'export'` error when **astro-component-tests** runs `npx astro build`.

I checked the code and find out that it creates astro config with **.js** extension and changed it into **.mjs** according to Astro documentation and it resolved this error well.

Ref:
https://docs.astro.build/en/guides/configuring-astro/
