### PR TITLE
Use "props" type from Astro Global interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-component-tester",
   "description": "Utility to test Astro components",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -4,7 +4,7 @@ import { dirname as getDirname, relative } from 'path';
 import { fileURLToPath } from 'url';
 import { createHash } from 'crypto';
 import { existsSync, rmSync } from 'fs';
-import { AstroUserConfig } from 'astro';
+import { AstroGlobal, AstroUserConfig } from 'astro';
 
 const dirname = (() => {
 	/* replace-in-file-dirname-start */
@@ -32,7 +32,7 @@ export interface BuildResult {
  * @param buildOptions Build options, such as forceBuild to force new builds instead of using cache
  * @returns The path to the built component
  */
-export async function buildComponent(path: string, props: Record<string, unknown>, buildOptions: BuildOption): Promise<BuildResult> {
+export async function buildComponent(path: string, props: AstroGlobal['props'], buildOptions: BuildOption): Promise<BuildResult> {
 	const hash = getHash({ path, props, astroConfig: buildOptions.astroConfig });
 
 	const projectRoot = dirname + '/.test/' + `test-${hash}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { readFile, rm, stat } from 'fs/promises';
 import { join } from 'path';
+import { AstroGlobal } from 'astro';
 import { buildComponent, BuildOption } from './builder.js';
 
 export interface ComponentOutput {
@@ -10,7 +11,7 @@ export interface ComponentOutput {
 	clean: () => Promise<void>;
 }
 
-export async function getComponentOutput(path: string, props: Record<string, unknown> = {}, buildOptions: BuildOption = {}): Promise<ComponentOutput> {
+export async function getComponentOutput(path: string, props: AstroGlobal['props'] = {}, buildOptions: BuildOption = {}): Promise<ComponentOutput> {
 	// Build the component
 	const component = await buildComponent(path, props, buildOptions);
 


### PR DESCRIPTION
I changed the **props** type according to **AstroGlobal** Interface, because your one crashes when I try using Props Interface from the component.

<img width="813" alt="image" src="https://user-images.githubusercontent.com/28218829/176405251-27ffb666-426a-4cae-bb3f-89252ee509e8.png">
