### PR TITLE
Only log errors when building components

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -65,7 +65,7 @@ export async function buildComponent(path: string, props: AstroGlobal['props'], 
 	}
 
 	// Build it using the Astro CLI
-	await build({ root: projectRoot });
+	await build({ root: projectRoot, logLevel: 'error' });
 
 	return {
 		projectRoot,


### PR DESCRIPTION
When switching to Astro’s programmatic `build()` in #11, I didn’t think about logging, so currently this is pretty hilariously verbose as it looks like you built an entire Astro project in your terminal for each render.

This PR sets the log level so that only errors are logged, which is generally a nicer experience.